### PR TITLE
fix: potential error in isTryCatchStatement

### DIFF
--- a/lib/rules/detect-unhandled-async-errors.js
+++ b/lib/rules/detect-unhandled-async-errors.js
@@ -39,6 +39,7 @@ function isIfWithReturn (bodyArg) {
 function isTryCatchStatement (bodyArg) {
   return bodyArg.type === 'TryStatement' &&
     bodyArg.handler.type === 'CatchClause' &&
+    bodyArg.handler.param &&
     /^(e|err|error|Error|anySpecificError)$/.test(bodyArg.handler.param.name)
 }
 

--- a/tests/lib/rules/detect-unhandled-async-errors.js
+++ b/tests/lib/rules/detect-unhandled-async-errors.js
@@ -19,8 +19,9 @@ const invalidIfWithThrow = "async function run() {const success = await alert('d
 const invalidIfWithThrowTwo = "async function run() {const success = await alert('do something'); if(err) throw new handle('error')}"
 const validCatch = "async function run(out) { await out.catch(error => alert('there is an error'))}"
 const invalidCatch = "async function run(out) { await out }"
+const validCatchError = "async function clientErrorHandler(err, req, res, nextMiddleware) { alert('there is an error') }"
 
-var ruleTester = new RuleTester({ 
+var ruleTester = new RuleTester({
 	parserOptions: { ecmaVersion: 2018 }
 })
 
@@ -75,5 +76,14 @@ ruleTester.run('detect-unhandled-async-errors', rule, {
 				message: ERROR_MSG
 			}]
 		}
+	]
+})
+
+ruleTester.run('detect-unhandled-async-errors', rule, {
+	valid: [
+		{ code: validCatchError }
+	],
+
+	invalid: [
 	]
 })


### PR DESCRIPTION
In some cases the `bodyArg.handler.param` can have the value `null` which causes the line on 42/43 to cause a runtime exception as it tries to access a property `name` on `null`