### PR TITLE
Fix TypeError when checking a try/finally block with no catch

### DIFF
--- a/lib/rules/detect-unhandled-async-errors.js
+++ b/lib/rules/detect-unhandled-async-errors.js
@@ -38,6 +38,7 @@ function isIfWithReturn (bodyArg) {
 
 function isTryCatchStatement (bodyArg) {
   return bodyArg.type === 'TryStatement' &&
+    bodyArg.handler &&
     bodyArg.handler.type === 'CatchClause' &&
     bodyArg.handler.param &&
     /^(e|err|error|Error|anySpecificError)$/.test(bodyArg.handler.param.name)

--- a/tests/lib/rules/detect-unhandled-async-errors.js
+++ b/tests/lib/rules/detect-unhandled-async-errors.js
@@ -20,6 +20,7 @@ const invalidIfWithThrowTwo = "async function run() {const success = await alert
 const validCatch = "async function run(out) { await out.catch(error => alert('there is an error'))}"
 const invalidCatch = "async function run(out) { await out }"
 const validCatchError = "async function clientErrorHandler(err, req, res, nextMiddleware) { alert('there is an error') }"
+const noCatch = "async function run(out) { try { await out; } finally { console.log('done'); } }"
 
 var ruleTester = new RuleTester({
 	parserOptions: { ecmaVersion: 2018 }
@@ -85,5 +86,18 @@ ruleTester.run('detect-unhandled-async-errors', rule, {
 	],
 
 	invalid: [
+	]
+})
+
+ruleTester.run('detect-unhandled-async-errors', rule, {
+	valid: [
+	],
+
+	invalid: [
+		{ code: noCatch,
+			errors: [{
+				message: ERROR_MSG
+			}]
+		 }
 	]
 })


### PR DESCRIPTION
Currently the detect-unhandled-async-errors rule raises a TypeError when scanning a try block with no catch, e.g.

```
async function fn() {
   try {
      await foo();
   } finally {
      console.log("done");
   }
}
```

results in an error:

```
TypeError: Cannot read properties of null (reading 'type')
Occurred while linting <source-filename>:<line>
Rule: "security-node/detect-unhandled-async-errors"
    at isTryCatchStatement (/Users/nkeynes/src/dylan/node_modules/.pnpm/eslint-plugin-security-node@1.1.4/node_modules/eslint-plugin-security-node/lib/rules/detect-unhandled-async-errors.js:41:21)
    at FunctionDeclaration (/Users/nkeynes/src/dylan/node_modules/.pnpm/eslint-plugin-security-node@1.1.4/node_modules/eslint-plugin-security-node/lib/rules/detect-unhandled-async-errors.js:113:19)
    at ruleErrorHandler (/Users/nkeynes/src/dylan/node_modules/.pnpm/eslint@8.50.0/node_modules/eslint/lib/linter/linter.js:1091:28)
    at /Users/nkeynes/src/dylan/node_modules/.pnpm/eslint@8.50.0/node_modules/eslint/lib/linter/safe-emitter.js:45:58
```

This PR just adds a check that the handler body exists (and corresponding test).